### PR TITLE
6to5

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.3",
   "description": "dev server and build tools for macropod projects",
   "dependencies": {
+    "6to5-core": "^3.5.3",
+    "6to5-loader": "^3.0.0",
     "autoprefixer-loader": "^1.0.0",
     "chai": "^1.10.0",
     "css-loader": "^0.9.1",
@@ -16,7 +18,7 @@
     "sass-loader": "^0.3.1",
     "style-loader": "^0.8.3",
     "url-loader": "~0.5.5",
-    "webpack": "^1.5.1",
+    "webpack": "^1.5.3",
     "webpack-dev-server": "^1.7.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "eslint": "^0.13.0",
     "file-loader": "^0.8.1",
     "html-webpack-plugin": "^1.1.0",
-    "jsx-loader": "^0.12.2",
     "mocha": "^2.1.0",
     "raw-loader": "~0.5.1",
     "react-hot-loader": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "dependencies": {
     "6to5-core": "^3.5.3",
     "6to5-loader": "^3.0.0",
+    "6to5-runtime": "^3.5.3",
     "autoprefixer-loader": "^1.0.0",
     "chai": "^1.10.0",
     "css-loader": "^0.9.1",
     "eslint": "^0.13.0",
     "file-loader": "^0.8.1",
-    "html-webpack-plugin": "^1.1.0",
     "mocha": "^2.1.0",
     "raw-loader": "~0.5.1",
     "react-hot-loader": "^1.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,9 @@ var testing = (process.env.NODE_ENV === 'testing');
 var plugins = [
   new webpack.IgnorePlugin(/vertx/),
   new webpack.NormalModuleReplacementPlugin(/^react$/, 'react/addons'),
+  new webpack.ProvidePlugin({
+    to5Runtime: 'imports?global=>window!exports-loader?global.to5Runtime!6to5/runtime'
+  }),
 ];
 
 if (!testing) {
@@ -30,7 +33,7 @@ if (!testing) {
   });
 }
 
-var jsxLoader = ['jsx-loader?harmony'];
+var jsxLoader = ['6to5?experimental=true&runtime=true'];
 
 if (release)  {
   plugins.push(new webpack.DefinePlugin({
@@ -82,7 +85,7 @@ var config = module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.jsx$/, loaders: jsxLoader },
+      { test: /\.js/, loaders: jsxLoader }, // includes js, jsx and even... .jslol
       {
         test: /\.scss$/,
         loaders: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 var webpack = require('webpack');
 var path = require('path');
 var pkg = require(process.cwd() + '/package.json');
-var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 var release = (process.env.NODE_ENV === 'production');
 var testing = (process.env.NODE_ENV === 'testing');
@@ -9,9 +8,6 @@ var testing = (process.env.NODE_ENV === 'testing');
 var plugins = [
   new webpack.IgnorePlugin(/vertx/),
   new webpack.NormalModuleReplacementPlugin(/^react$/, 'react/addons'),
-  new webpack.ProvidePlugin({
-    to5Runtime: 'imports?global=>window!exports-loader?global.to5Runtime!6to5/runtime'
-  }),
 ];
 
 if (!testing) {
@@ -33,7 +29,7 @@ if (!testing) {
   });
 }
 
-var jsxLoader = ['6to5?experimental=true&runtime=true'];
+var jsxLoader = ['6to5?experimental&optional=selfContained'];
 
 if (release)  {
   plugins.push(new webpack.DefinePlugin({
@@ -58,6 +54,7 @@ if (testing) {
     vendor: Object.keys(pkg.dependencies).filter(function(e) {
       return [
         'macropod-components',
+        '6to5-runtime',
         'react-components', //TODO: make this finer
         'open-sans',
       ].indexOf(e) === -1;
@@ -85,7 +82,8 @@ var config = module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js/, loaders: jsxLoader }, // includes js, jsx and even... .jslol
+      { test: /\.js$/, exclude: /node_modules/, loaders: jsxLoader },
+      { test: /\.jsx$/, loaders: jsxLoader }, // its slow... but some of our deps have jsx :/
       {
         test: /\.scss$/,
         loaders: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,6 @@ if (testing) {
     vendor: Object.keys(pkg.dependencies).filter(function(e) {
       return [
         'macropod-components',
-        '6to5-runtime',
         'react-components', //TODO: make this finer
         'open-sans',
       ].indexOf(e) === -1;
@@ -83,7 +82,7 @@ var config = module.exports = {
   module: {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loaders: jsxLoader },
-      { test: /\.jsx$/, loaders: jsxLoader }, // its slow... but some of our deps have jsx :/
+      { test: /\.jsx$/, loaders: jsxLoader }, // including node_modules in this rule because Khan/react-components does not precompile their jsx
       {
         test: /\.scss$/,
         loaders: [


### PR DESCRIPTION
Uses 6to5 to allow us to use more es6 features than jsx-loader does.
https://6to5.org/docs/compare/