### PR TITLE
Make the linter more structure-agnostic

### DIFF
--- a/bin/lint.sh
+++ b/bin/lint.sh
@@ -2,4 +2,4 @@
 
 PATH="./node_modules/macropod-tools/node_modules/.bin:${PATH}"
 
-eslint -c ./node_modules/macropod-tools/.eslintrc --ext .js --ext .jsx app packages
+eslint -c ./node_modules/macropod-tools/.eslintrc --ext .js --ext .jsx $(find . -type d -depth 1 | grep -E '(app|packages)$')

--- a/bin/start-test.sh
+++ b/bin/start-test.sh
@@ -11,4 +11,4 @@ webpack-dev-server \
 	--display-error-details --progress --colors --port ${PORT} \
 	--display-chunks --output-public-path http://127.0.0.1:${PORT}/ \
 	--output-file bundle.js --content-base ./node_modules/macropod-tools/testing \
-  $(find app -name '*_test.jsx')
+  $(find . -name '*_test.jsx')


### PR DESCRIPTION
No longer fails entirely if one of app or packages is missing.
Also open up the test server to tests outside of `app`.