### PR TITLE
Fix a bug in the dev server

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -12,6 +12,6 @@ webpack-dev-server \
   --history-api-fallback \
   --hot \
   --inline \
-  --output-public-path http://127.0.0.1:${PORT}/
+  --output-public-path http://127.0.0.1:${PORT}/ \
   --port ${PORT} \
-  --progress \
+  --progress


### PR DESCRIPTION
The dev server will no longer listen on two ports if you set a port other than 8080