### PR TITLE
Fix a bug specific to building macropod-components

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,7 +88,7 @@ var config = module.exports = {
       },
       {
         test: /\.(js|jsx)$/,
-        include: /macropod-components/,
+        include: /node_modules[\\\/]macropod-components/,
         loaders: jsxLoader,
       },
       {


### PR DESCRIPTION
when checked out to a path containing `macropod-components`, macropod-components would fail to build because the second jsxLoader regex matched everything inside it, which doesn't work!