### PR TITLE
Don't flag unused function arguments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "no-dupe-args": 2,
     "no-multiple-empty-lines": 2,
     "no-underscore-dangle": 0,
+    "no-unused-vars": [2, {vars: "all", args: "none"}],
     "no-var": 1,
     "one-var": [2, "never"],
     "quotes": [2, "single"],


### PR DESCRIPTION
There are various examples where it's useful to specific function arguments even when they're unused.
eg.
Event handlers should have the event in their args even if it's unused to avoid confusion when adding extra arguments to the handler.

willTransitionTo: function(transition, params, query)
Mostly the arguments to willTransitionTo go unused, but specifying them allows the reader to use them without having to look up documentation.