### PR TITLE
PostCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,17 @@
     "style-loader": "^0.12.3",
     "url-loader": "~0.5.5",
     "webpack": "^1.5.3",
-    "webpack-dev-server": "^1.7.0"
+    "webpack-dev-server": "^1.7.0",
+    "postcss-loader": "^0.4.2",
+    "autoprefixer": "^5.1.1",
+    "postcss-mixins" : "^0.1.1",
+    "postcss-simple-vars" : "^0.3.0",
+    "postcss-nested" : "^0.2.2",
+    "postcss-simple-extend": "^0.3.1",
+    "postcss-import": "^5.2.2",
+    "postcss-calc": "^4.0.1",
+    "postcss-color-function": "^1.2.0",
+    "postcss-url": "^3.2.0"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,15 @@
 var webpack = require('webpack');
 var path = require('path');
 var pkg = require(process.cwd() + '/package.json');
+var autoprefixer = require('autoprefixer');
+var postcssMixins = require('postcss-mixins');
+var postcssVars = require('postcss-simple-vars');
+var postcssNested = require('postcss-nested');
+var postcssExtend = require('postcss-simple-extend');
+var postcssImport = require('postcss-import');
+var postcssCalc = require('postcss-calc');
+var postcssColor = require('postcss-color-function');
+var postcssUrl = require('postcss-url');
 
 var release = (process.env.NODE_ENV === 'production');
 var testing = (process.env.NODE_ENV === 'testing');
@@ -54,8 +63,8 @@ if (testing) {
     vendor: Object.keys(pkg.dependencies).filter(function(e) {
       return [
         'macropod-components',
+        'open-sands',
         'react-components', //TODO: make this finer
-        'open-sans',
         'pouch-client',
       ].indexOf(e) === -1;
     }),
@@ -76,7 +85,7 @@ var config = module.exports = {
     modulesDirectories: ['node_modules', 'node_modules/macropod-tools/node_modules']
   },
   resolve: {
-    extensions: ['', '.js', '.jsx', '.scss', '.css'],
+    extensions: ['', '.js', '.jsx', '.scss', '.pcss', '.css'],
     modulesDirectories: ['node_modules', 'node_modules/macropod-tools/node_modules'],
     packageMains: ['browser', 'main', 'style'],
   },
@@ -109,7 +118,15 @@ var config = module.exports = {
           'style-loader',
           'css-loader',
           'autoprefixer-loader',
-          'sass-loader?includePaths[]=./app/base/style,includePaths[]=./node_modules,includePaths[]=./style,includePaths[]=./node_modules/macropod-components/style,includePaths[]=./app/base/style,includePaths[]=./app/base/components,includePaths[]=./node_modules,includePaths[]=./node_modules/bootstrap-sass/assets/fonts'
+          'sass-loader?includePaths[]=./app/base/style,includePaths[]=./node_modules,includePaths[]=./style,includePaths[]=./node_modules/macropod-components/style,includePaths[]=./app/base/style,includePaths[]=./app/base/components,includePaths[]=./node_modules,includePaths[]=./node_modules/bootstrap-sass/assets/fonts',
+        ],
+      },
+      {
+        test: /\.pcss$/,
+        loaders: [
+          'style-loader',
+          'css-loader',
+          'postcss-loader',
         ],
       },
       {
@@ -150,4 +167,15 @@ var config = module.exports = {
       },
     ],
   },
+  postcss: [
+    postcssImport,
+    postcssUrl(),
+    postcssMixins,
+    postcssExtend,
+    postcssVars,
+    postcssCalc(),
+    postcssColor(),
+    postcssNested,
+    autoprefixer,
+  ],
 };


### PR DESCRIPTION
### `.scss` remains a thing
Rather than strip `.scss` support completely, the loader still exists to support applications that haven't been ported yet (`pouch`). It's also a nice safe guard, if `macropod-components` gets merged today, we don't have any rush on getting `stack-client` merged.

### `.pcss` is now a thing
Files with the extension `.pcss` get treated to `post-css` and a barrage of plugins. The intent is to keep the syntax as close as possible to `.scss`, so we can port ourselves away from sass with as little friction as possible. `.pcss` is **a temporary solution** until we get `css-loader`'s module system up and running with plain `.css` files.

----

Tested with:
- https://github.com/macropodhq/macropod-components/tree/postcss-james
- https://github.com/macropodhq/macropod-components/tree/master
- https://github.com/macropodhq/stack-client/tree/postcss
- https://github.com/macropodhq/stack-client/tree/master (tested with `macropod-components#postcss-james` and `macropod-components#master` - `postcss` might need a little work reffing files)