### PR TITLE
update autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.24",
   "description": "Development server and build tools for webpack and React, used by Macropod's products.",
   "dependencies": {
-    "autoprefixer-loader": "^1.0.0",
+    "autoprefixer-loader": "^2.0.0",
     "babel-core": "^5.4.7",
     "babel-eslint": "^3.1.9",
     "babel-loader": "^5.1.3",


### PR DESCRIPTION
fixes the `Autoprefixer's process() method is deprecated and will removed in next major release. Use postcss([autoprefixer]).process() instead` warning. finally.