### PR TITLE
autoprefix mcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.27",
   "description": "Development server and build tools for webpack and React, used by Macropod's products.",
   "dependencies": {
+    "autoprefixer-core": "^5.2.1",
     "autoprefixer-loader": "^2.0.0",
     "babel-core": "^5.4.7",
     "babel-eslint": "^4.0.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ var webpack = require('webpack');
 var path = require('path');
 var pkg = require(process.cwd() + '/package.json');
 var constants = require('postcss-local-constants');
+var autoprefixer = require('autoprefixer-core');
 
 var release = (process.env.NODE_ENV === 'production');
 var testing = (process.env.NODE_ENV === 'testing');
@@ -178,5 +179,6 @@ var config = module.exports = {
   },
   postcss: [
     constants(),
+    autoprefixer({ browsers: ['last 3 versions'] }),
   ],
 };


### PR DESCRIPTION
long time coming.

rather than make `scss` use another variant of the postcss config, i just left the autoprefix loader in there as well.

open to running postcss over scss as well (would only be the constants and autoprefixer plugins), but we should be removing it soon anyway, so...