### PR TITLE
Update `display-name` lint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,7 +37,7 @@
     "space-before-blocks": 1,
     "space-before-function-paren": [1, "never"],
     "strict": [0, "never"],
-    "react/display-name": 2,
+    "react/display-name": [2, {acceptTranspilerName: true}],
     "react/jsx-no-undef": 1,
     "react/jsx-quotes": [2, "double"],
     "react/jsx-uses-react": 1,


### PR DESCRIPTION
Now accepting the name the transpiler gets, from ES6 class names or variable names